### PR TITLE
WDP190202-4

### DIFF
--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -27,6 +27,7 @@
     }
 
     .buttons {
+      visibility: hidden;
       display: flex;
       justify-content: space-between;
     }

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -79,4 +79,16 @@
     justify-content: space-between;
     align-items: center;
   }
+
+  &:hover {
+    .buttons {
+      visibility: visible;
+    }
+
+    .price {
+      .no-hover {
+        background-color: $primary;
+      }
+    }
+  }
 }

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -87,7 +87,7 @@
     }
 
     .price {
-      .no-hover {
+      .btn-main-small {
         background-color: $primary;
       }
     }


### PR DESCRIPTION
Opis problemu:
Buttony "Quick view" oraz "Add to cart" powinny być widoczne tylko na hover całego boksa z produktem. Wtedy też powinno zmieniać się tło ceny. 
Rozwiązanie:
- dodałem hover dla boksa zmieniający visibility diva klasy:  .buttons 
- background-color na $primary dla diva klasy:  .no-hover.