### PR TITLE
WDP190202-13

### DIFF
--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -5,7 +5,7 @@
         <div class="col text-left">
           <ul>
             <li>
-              <a href="#">USD <i class="fas fa-caret-down"></i></a>
+              <a href="#">USD<i class="fas fa-caret-down"></i></a>
             </li>
             <li>
               <a href="#">English <i class="fas fa-caret-down"></i></a>

--- a/src/partials/30_section-features.html
+++ b/src/partials/30_section-features.html
@@ -1,7 +1,7 @@
 <div class="section--features">
   <div class="container">
     <div class="row">
-      <div class="col">
+      <div class="col-6 col-sm-6 col-md-3">
         <a href="#" class="feature-box active">
           <div class="icon"><i class="fas fa-truck"></i></div>
           <div class="content">
@@ -10,7 +10,7 @@
           </div>
         </a>
       </div>
-      <div class="col">
+      <div class="col-6 col-sm-6 col-md-3">
         <a href="#" class="feature-box">
           <div class="icon"><i class="fas fa-headphones"></i></div>
           <div class="content">
@@ -19,7 +19,7 @@
           </div>
         </a>
       </div>
-      <div class="col">
+      <div class="col-6 col-sm-6 col-md-3">
         <a href="#" class="feature-box">
           <div class="icon"><i class="fas fa-reply-all"></i></div>
           <div class="content">
@@ -28,7 +28,7 @@
           </div>
         </a>
       </div>
-      <div class="col">
+      <div class="col-6 col-sm-6 col-md-3">
         <a href="#" class="feature-box">
           <div class="icon"><i class="fas fa-bullhorn"></i></div>
           <div class="content">

--- a/src/sass/components/_feature-box.scss
+++ b/src/sass/components/_feature-box.scss
@@ -3,6 +3,7 @@
   border: 1px solid #b6b6b6;
   text-align: center;
   margin-top: 40px;
+  min-height: 140px;
 
   .icon {
     transform: translateY(-50%);


### PR DESCRIPTION
**Problem:**
Karty korzyści "Free shipping" sypią się w trybach responsive.
Klient chce w trybach tablet i mobile mieć je w 2 rzędach, po 2 elementy w każdym, ale elementy w jednym rzędzie (obok siebie) nie powinny się różnić wysokością. 
**Rozwiązanie:**
Dodałam RWD bootstprapa i min-height do kart korzyści.