### PR TITLE
WDP190202-30

### DIFF
--- a/src/partials/50_section-products.html
+++ b/src/partials/50_section-products.html
@@ -16,7 +16,7 @@
       </div>
     </div>
     <div class="my-slider">
-      <div class="col-md-3 col-sm-6 col-xs-12 slider-item">
+      <div class="slider-item">
         <div class="product-box">
           <div class="photo">
             <img src="images/product-box/chair-1.jpg" alt="" />
@@ -24,8 +24,8 @@
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
               <a href="#" class="btn-main-small">
-                <i class="fa fa-shopping-basket"></i> ADD TO CART</a
-              >
+                <i class="fa fa-shopping-basket"></i> ADD TO CART
+              </a>
             </div>
           </div>
           <div class="content">
@@ -48,16 +48,15 @@
           </div>
         </div>
       </div>
-      <div class="col-md-3 col-sm-6 col-xs-12 slider-item">
+      <div class="slider-item">
         <div class="product-box">
           <div class="photo">
             <img src="images/product-box/chair-2.jpg" alt="" />
-            <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
               <a href="#" class="btn-main-small">
-                <i class="fa fa-shopping-basket"></i> ADD TO CART</a
-              >
+                <i class="fa fa-shopping-basket"></i> ADD TO CART
+              </a>
             </div>
           </div>
           <div class="content">
@@ -72,14 +71,14 @@
             <div class="outlines">
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline active">
-                <i class="fas fa-exchange-alt"></i
-              ></a>
+                <i class="fas fa-exchange-alt"></i>
+              </a>
             </div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
       </div>
-      <div class="col-md-3 col-sm-6 col-xs-12 slider-item">
+      <div class="slider-item">
         <div class="product-box">
           <div class="photo">
             <img src="images/product-box/chair-3.jpg" alt="" />
@@ -87,8 +86,8 @@
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
               <a href="#" class="btn-main-small">
-                <i class="fa fa-shopping-basket"></i> ADD TO CART</a
-              >
+                <i class="fa fa-shopping-basket"></i> ADD TO CART
+              </a>
             </div>
           </div>
           <div class="content">
@@ -103,8 +102,8 @@
             <div class="outlines">
               <a href="#" class="btn-outline active"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline active">
-                <i class="fas fa-exchange-alt"></i
-              ></a>
+                <i class="fas fa-exchange-alt"></i>
+              </a>
             </div>
             <div class="price">
               <div class="old-price">$ 100.00</div>
@@ -113,16 +112,15 @@
           </div>
         </div>
       </div>
-      <div class="col-md-3 col-sm-6 col-xs-12 slider-item">
+      <div class="slider-item">
         <div class="product-box">
           <div class="photo">
             <img src="images/product-box/chair-4.jpg" alt="" />
-            <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
               <a href="#" class="btn-main-small">
-                <i class="fa fa-shopping-basket"></i> ADD TO CART</a
-              >
+                <i class="fa fa-shopping-basket"></i> ADD TO CART
+              </a>
             </div>
           </div>
           <div class="content">
@@ -142,16 +140,15 @@
           </div>
         </div>
       </div>
-      <div class="col-md-3 col-sm-6 col-xs-12 slider-item">
+      <div class="slider-item">
         <div class="product-box">
           <div class="photo">
             <img src="images/product-box/chair-5.jpg" alt="" />
-            <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
               <a href="#" class="btn-main-small">
-                <i class="fa fa-shopping-basket"></i> ADD TO CART</a
-              >
+                <i class="fa fa-shopping-basket"></i> ADD TO CART
+              </a>
             </div>
           </div>
           <div class="content">
@@ -171,7 +168,7 @@
           </div>
         </div>
       </div>
-      <div class="col-md-3 col-sm-6 col-xs-12 slider-item">
+      <div class="slider-item">
         <div class="product-box">
           <div class="photo">
             <img src="images/product-box/chair-6.jpg" alt="" />
@@ -179,8 +176,8 @@
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
               <a href="#" class="btn-main-small">
-                <i class="fa fa-shopping-basket"></i> ADD TO CART</a
-              >
+                <i class="fa fa-shopping-basket"></i> ADD TO CART
+              </a>
             </div>
           </div>
           <div class="content">
@@ -203,16 +200,15 @@
           </div>
         </div>
       </div>
-      <div class="col-md-3 col-sm-6 col-xs-12 slider-item">
+      <div class="slider-item">
         <div class="product-box">
           <div class="photo">
             <img src="images/product-box/chair-7.jpg" alt="" />
-            <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
               <a href="#" class="btn-main-small">
-                <i class="fa fa-shopping-basket"></i> ADD TO CART</a
-              >
+                <i class="fa fa-shopping-basket"></i> ADD TO CART
+              </a>
             </div>
           </div>
           <div class="content">
@@ -232,16 +228,15 @@
           </div>
         </div>
       </div>
-      <div class="col-md-3 col-sm-6 col-xs-12 slider-item">
+      <div class="slider-item">
         <div class="product-box">
           <div class="photo">
             <img src="images/product-box/chair-8.jpg" alt="" />
-            <div class="sale">sale</div>
             <div class="buttons">
               <a href="#" class="btn-main-small">Quick View</a>
               <a href="#" class="btn-main-small">
-                <i class="fa fa-shopping-basket"></i> ADD TO CART</a
-              >
+                <i class="fa fa-shopping-basket"></i> ADD TO CART
+              </a>
             </div>
           </div>
           <div class="content">

--- a/src/partials/75_section-brands.html
+++ b/src/partials/75_section-brands.html
@@ -1,14 +1,22 @@
 <section class="section--brands">
   <div class="container">
-    <div class="brands-wrapper">
-      <div class="arrow"><</div>
-      <img src="images/brands/brand1.png" alt="" />
-      <img src="images/brands/brand2.png" alt="" />
-      <img src="images/brands/brand3.png" alt="" />
-      <img src="images/brands/brand4.png" alt="" />
-      <img src="images/brands/brand5.png" alt="" />
-      <img src="images/brands/brand1.png" alt="" />
-      <div class="arrow">></div>
+    <div class="brands-wrapper d-flex align-items-center">
+      <div class="arrow left"><</div>
+      <div class="brands-slider d-flex justify-content-around">
+        <img src="images/brands/brand1.png" alt="" />
+        <img src="images/brands/brand2.png" alt="" />
+        <img src="images/brands/brand3.png" alt="" />
+        <img src="images/brands/brand4.png" alt="" />
+        <img src="images/brands/brand5.png" alt="" />
+        <img src="images/brands/brand1.png" alt="" />
+        <img src="images/brands/brand1.png" alt="" />
+        <img src="images/brands/brand2.png" alt="" />
+        <img src="images/brands/brand3.png" alt="" />
+        <img src="images/brands/brand4.png" alt="" />
+        <img src="images/brands/brand5.png" alt="" />
+        <img src="images/brands/brand1.png" alt="" />
+      </div>
+      <div class="arrow right">></div>
     </div>
   </div>
 </section>

--- a/src/sass/components/_section--brands.scss
+++ b/src/sass/components/_section--brands.scss
@@ -5,9 +5,6 @@
   .brands-wrapper {
     border-top: 1px solid #b6b6b6;
     border-bottom: 1px solid #b6b6b6;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
     width: 100%;
 
     .arrow {
@@ -18,6 +15,7 @@
       color: #fff;
       margin: 20px 0;
       cursor: pointer;
+
       &:hover {
         color: $primary;
       }

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -10,34 +10,6 @@
       event.preventDefault();
     });
   });
-
-  // Add dots to menu as carousel nav
-  function ChangeDotsNumber () {
-    let pages;
-    let carouselDots = document.querySelector('.carousel-dots');
-    let sliderItems = document.querySelectorAll('.slider-item');
-    let vPortWidth = document.body.clientWidth;
-    // Reset number
-    carouselDots.innerHTML = '';
-    // Numbers of dots RWD
-    if (vPortWidth >= 992) {
-      pages = sliderItems.length / 3;
-    } else if (vPortWidth >= 572) {
-      pages = sliderItems.length / 2;
-    } else if (vPortWidth <= 567) {
-      pages = sliderItems.length;
-    }
-
-    for (let i = 0; i < pages; i++) {
-      carouselDots.insertAdjacentHTML('afterbegin', '<li><a></a></li>');
-    }
-  }
-  ChangeDotsNumber();
-  // Change number when resized
-  window.addEventListener('resize', function () {
-    ChangeDotsNumber();
-  });
-
   // MENU-BAR dropdown for small devices
   var showMenuBtn = document.querySelector('.menu-list-display');
   var menuList = document.getElementById('dropdown-menu');
@@ -45,5 +17,9 @@
   showMenuBtn.addEventListener('click', function () {
     menuList.classList.toggle('dropdown');
     showMenuBtn.classList.toggle('active');
+  });
+  // Change number when resized
+  window.addEventListener('resize', function () {
+    window.location.reload(true);
   });
 })();

--- a/src/scripts/carousel.js
+++ b/src/scripts/carousel.js
@@ -1,26 +1,9 @@
 import { tns } from '../../node_modules/tiny-slider/src/tiny-slider';
+// calling function ChangeDotsNumber
+ChangeDotsNumber();
 
-let slider = tns({
-  container: '.my-slider',
-  navContainer: '.carousel-dots',
-  items: 1,
-  controls: false,
-  nav: true,
-  responsive: {
-    576: {
-      items: 2
-    },
-    992: {
-      items: 3
-    }
-  },
-  slideBy: 'page',
-  mouseDrag: true,
-  swipeAngle: false,
-  loop: false
-});
-
-let promoLeft = tns({
+// Slider section-promotion left
+tns({
   container: '.slider-promo-left',
   navContainer: '.dots-deals',
   items: 1,
@@ -38,7 +21,8 @@ let promoLeft = tns({
   autoplayHoverPause: true
 });
 
-let promoRight = tns({
+// Slider section-promotion right
+tns({
   container: '.slider-promo-right',
   controlsContainer: '.promotion-btns',
   items: 1,
@@ -54,12 +38,80 @@ let promoRight = tns({
   autoplay: false
 });
 
-let resizeTimeout;
-window.addEventListener('resize', event => {
-  clearTimeout(resizeTimeout);
-  resizeTimeout = setTimeout(() => {
-    slider.rebuild();
-    promoLeft.rebuild();
-    promoRight.rebuild();
-  }, 500);
+// Slider section-brands
+tns({
+  container: '.brands-slider',
+  prevButton: '.left',
+  nextButton: '.right',
+  items: 2,
+  responsive: {
+    576: {
+      items: 3
+    },
+    768: {
+      items: 4
+    },
+    992: {
+      items: 6
+    }
+  },
+  controls: true,
+  nav: false,
+  slideBy: 'page',
+  mouseDrag: true,
+  touch: true,
+  swipeAngle: false,
+  loop: true,
+  autoplay: true,
+  rewind: false,
+  speed: 4000,
+  autoplayTimeout: 8000,
+  autoplayButtonOutput: false
 });
+
+// Slider section-products, add dots to menu as carousel nav
+function ChangeDotsNumber () {
+  let pages;
+  let carouselDots = document.querySelector('.carousel-dots');
+  let sliderItems = document.querySelectorAll('.slider-item');
+  let vPortWidth = document.body.clientWidth;
+  // Reset number
+  carouselDots.innerHTML = '';
+  // Numbers of dots RWD
+  if (vPortWidth >= 992) {
+    pages = sliderItems.length / 3;
+  } else if (vPortWidth >= 576) {
+    pages = sliderItems.length / 2;
+  } else if (vPortWidth <= 575) {
+    pages = sliderItems.length;
+  }
+
+  for (let i = 0; i < pages; i++) {
+    carouselDots.insertAdjacentHTML('afterbegin', '<li><a></a></li>');
+  }
+  // Slider section-products options
+  tns({
+    container: '.my-slider',
+    navContainer: '.carousel-dots',
+    items: 1,
+    gutter: 0,
+    responsive: {
+      576: {
+        gutter: 5,
+        items: 2
+      },
+      992: {
+        gutter: 15,
+        items: 3
+      }
+    },
+    controls: false,
+    speed: 2000,
+    nav: true,
+    slideBy: 'page',
+    mouseDrag: false,
+    touch: true,
+    swipeAngle: false,
+    loop: true
+  });
+}


### PR DESCRIPTION
**Opis:**
Należy dodać skrypt to animacji slidera z markami, tak aby strzałki przesuwały slider o tyle elementów, ile jest widoczne przy danej szerokości ekranu (np. w wersji desktop jest ich 6).

**Co zrobiłem:**

1. Naprawiłem poprzednie slidery nie ma już błędów w konsoli:
- w _50_section-products.html_ usunąłem grida bootstarap był niepotrzebny tiny slider sam oblicza potrzebną wielkość itema
- w _app.js_ wyciąłem funkcję ChangeDotsNumber i przeniosłem do _carousel.js_, zmieniłem funkcję na resize okna, teraz wczytuje okno od nowa po zmianie szerokości.
- w _carousel.js_ najpierw odwołuję się do funkcji ChangeDotsNumber w której zawarłem opcję dla slidera produktów. dzięki temu najpierw liczy ile ma być kropek a potem buduje slidera.
(w firefoxie w trybie resposive trzeba ustawić odświeżanie strony po zmianie identyfikatora - po zmianie urządzenia wczytuje stronę od nowa - co jest logiczne)
2. Dodałem slidera do __section--brands_:
- w  __section--brands.html_ dodałem div z klasą brands-slider i klasy styli
- w __section--brands.scss_ usunąłem zbędne style dla wrappera.
 